### PR TITLE
small fixes to support newer versions of numpy and pandas

### DIFF
--- a/aslib_scenario/aslib_scenario.py
+++ b/aslib_scenario/aslib_scenario.py
@@ -406,9 +406,9 @@ class ASlibScenario(object):
         # group performance data by mean value across repetitions
         for perf in self.performance_measure:
             self.performance_data_all.append(
-                perf_data.groupby(['instance_id', 'algorithm']).median().unstack(
-                    'algorithm')[perf]
-            )
+                # drop runstatus to support newer versions of median() in pandas
+                perf_data.drop(columns=["runstatus"]).groupby(['instance_id', 'algorithm'])
+                .median().unstack('algorithm')[perf])
 
         self.performance_data = self.performance_data_all[0]
 
@@ -559,7 +559,7 @@ class ASlibScenario(object):
         data = np.array(arff_dict["data"])
         cols = list(map(lambda x: x[0], arff_dict["attributes"][1:]))
         imputed_feature_cost_data = pd.DataFrame(
-            data[:,1:], columns=cols, dtype=np.float)
+            data[:,1:], columns=cols, dtype=float)
         
         # imputation has to be before the grouping
         imputed_feature_cost_data[pd.isnull(imputed_feature_cost_data)] = 0
@@ -701,7 +701,7 @@ class ASlibScenario(object):
         data = np.array(arff_dict["data"])
         cols = list(map(lambda x: x[0], arff_dict["attributes"][1:]))
         self.cv_data = pd.DataFrame(
-            data[:, 1:], index=data[:, 0], columns=cols, dtype=np.float)
+            data[:, 1:], index=data[:, 0], columns=cols, dtype=float)
         # use only first cv repetitions
         self.cv_data = self.cv_data[self.cv_data["repetition"] == 1]
         self.cv_data = self.cv_data.drop("repetition", axis=1)
@@ -836,7 +836,7 @@ class ASlibScenario(object):
 
         kf = KFold(n_splits=n_folds, shuffle=True)
         self.cv_data = pd.DataFrame(
-            data=np.zeros(len(self.instances)), index=self.instances, columns=["fold"], dtype=np.float)
+            data=np.zeros(len(self.instances)), index=self.instances, columns=["fold"], dtype=float)
         
         for indx, (train, test) in enumerate(kf.split(self.instances)):
             # print(self.cv_data.loc(np.array(self.instances[test]).tolist()))


### PR DESCRIPTION
Due to two issues ASlibScenario does not support current versions of pandas and numpy:

1) In previous versions, when `median()` was called on a pandas groupBy object non-numeric columns were dropped. Now, we have to drop them manually, i.e. remove the column "runstatus" when aggregating the median 

2) The alias `np.float` for Python's built-in float type was removed, now we have to define `dtype=float` instead